### PR TITLE
chore: remove unused yaml import (ruff F401)

### DIFF
--- a/tests/test_triage_pipeline.py
+++ b/tests/test_triage_pipeline.py
@@ -3,8 +3,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
-
 ROOT = Path(__file__).resolve().parents[1]
 TRIAGE_DOCS = ROOT / "docs" / "triage_pack_2025-09-13" / "core"
 


### PR DESCRIPTION
## Summary
- remove unused yaml import from triage pipeline tests to satisfy linter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced1977f44832b9bb9e3528d3d8185